### PR TITLE
Adding PR Check file

### DIFF
--- a/file.yml
+++ b/file.yml
@@ -1,0 +1,17 @@
+name: PR Check
+
+on: [pull_request]
+
+jobs:
+  Scanning_with:
+    uses: akeylesslabs/akeyless-security/.github/workflows/reusable-scanner.yaml@main
+    strategy:
+      fail-fast: false
+      matrix:
+        scan_type: ["SAST", "SCA"]
+    with:
+      branch_name: ${{ github.head_ref }}
+      repository_name: ${{ github.repository }}
+      event_name: ${{ github.event_name }}
+      scan_type: ${{ matrix.scan_type }}
+    secrets: inherit


### PR DESCRIPTION
This PR adds the PR required file for security checks. It will check each PR with our tools and fail if we find HiGH or CRITICAL findins.