### PR TITLE
ASM-19589: SCA remediation - fix all fixable dependency vulnerabilities (50 -> 0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,8 @@
 
 
     <properties>
-        <fasterxml_version>2.19.0</fasterxml_version>
+        <fasterxml_version>2.22.1</fasterxml_version>
+        <netty_version>4.1.137.Final</netty_version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
@@ -39,7 +40,7 @@
         <dependency>
             <groupId>com.google.auth</groupId>
             <artifactId>google-auth-library-oauth2-http</artifactId>
-            <version>1.5.3</version>
+            <version>1.50.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
@@ -64,14 +65,14 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.15.2</version>
+            <version>1.18.4</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.netty/netty-handler -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.121.Final</version>
+            <version>${netty_version}</version>
         </dependency>
 
         <!-- Test dependencies -->
@@ -82,6 +83,19 @@
             <scope>test</scope>
         </dependency>
    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Force a non-vulnerable Netty version for all transitive Netty artifacts -->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty_version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
SCA remediation for **ASM-19589**. Trivy fs scan (vuln scanners, offline) on `pom.xml` reported **50 findings (21 HIGH / 26 MEDIUM / 3 LOW)** - all with released fixes. After this change the same scan reports **0 findings**.

## Fixes by manifest

| Manifest | Package | Old | New | How | CVEs addressed |
|---|---|---|---|---|---|
| pom.xml | com.fasterxml.jackson.core:jackson-databind (+jackson-core) | 2.19.0 | 2.22.1 | bump `fasterxml_version` property | CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54515, CVE-2026-59888, GHSA-r7wm-3cxj-wff9, GHSA-72hv-8253-57qq |
| pom.xml | io.netty:netty-handler (direct) | 4.1.121.Final | 4.1.137.Final | new `netty_version` property | CVE-2026-44249, CVE-2026-45416, CVE-2026-50010 |
| pom.xml | io.netty:* (transitive via azure-identity: netty-codec, netty-codec-http, netty-codec-http2, netty-codec-dns, netty-resolver-dns, netty-handler-proxy, netty-transport-native-epoll/kqueue) | 4.1.112-4.1.121.Final | 4.1.137.Final | new `<dependencyManagement>` import of `io.netty:netty-bom:4.1.137.Final` | CVE-2025-55163, CVE-2025-58056, CVE-2025-58057, CVE-2025-67735, CVE-2026-33870, CVE-2026-33871, CVE-2026-41417, CVE-2026-42578..42585, CVE-2026-42587, CVE-2026-45536, CVE-2026-45673/45674, CVE-2026-47244, CVE-2026-47691, CVE-2026-48043, CVE-2026-50020, CVE-2026-50560, CVE-2026-55831/55833, CVE-2026-56745/56746, CVE-2026-56819, CVE-2026-59898..59901, CVE-2026-59921, GHSA-mfg7-5gfp-c4w3 |
| pom.xml | com.google.guava:guava (transitive via google-auth-library) | 31.0.1-android | 33.6.0-jre | bump google-auth-library-oauth2-http 1.5.3 -> 1.50.0 | CVE-2023-2976, CVE-2020-8908 |
| pom.xml | io.projectreactor.netty:reactor-netty-http (transitive via azure-identity) | 1.0.48 | 1.2.18 | bump azure-identity 1.15.2 -> 1.18.4 | CVE-2025-22227 |
| pom.xml | com.nimbusds:nimbus-jose-jwt (transitive via msal4j) | 9.40 | removed from tree (msal4j 1.23.1 shades its OIDC deps) | bump azure-identity 1.15.2 -> 1.18.4 | CVE-2025-53864 |

## Code changes required by bumps

None. Source uses only stable public APIs that are unchanged across the bumps, verified by review of all 6 source files (`GoogleCredentials`/`IdTokenCredentials` in `GcpCloudIdProvider`, `DefaultAzureCredentialBuilder`/`TokenRequestContext` in `AzureCloudIdProvider`, AWS SDK v2 `Aws4Signer` path in `AwsCloudIdProvider` - aws-core was not bumped) and by a clean compile plus the runtime smoke test below. Java 8 compiler target is preserved; all bumped versions (jackson 2.x, netty 4.1.x, azure-identity 1.18.x, google-auth-library 1.50.0) remain Java-8 compatible.

## Residual findings

None. Post-fix `trivy fs --scanners vuln --offline-scan` on the tree: **0 findings**. No findings were skipped, downgraded, or left without a fix.

## Verification / TEST EVIDENCE

All verification ran on a local workstation (macOS, Maven with JDK 11, `-Drevision=1.0.0-SNAPSHOT` since the pom version is CI-injected). **No production/SaaS endpoints and no internet-facing gateways were called**; the only network access was Maven Central artifact downloads.

1. `xmllint --noout pom.xml` - pass (valid XML).
2. `mvn -B clean package -Drevision=1.0.0-SNAPSHOT` - **BUILD SUCCESS** (9.5 s): compiles all sources and builds the `jar-with-dependencies` assembly against the new versions.
3. `mvn -B test -Drevision=1.0.0-SNAPSHOT` - BUILD SUCCESS; surefire 3.5.4 reports **"No tests to run"**: this repository contains **no test sources at all** (no `src/test`), so there is no unit suite to execute - on the base branch or on this one.
4. **Offline runtime smoke test** (written for this PR, compiled and run against the built fat jar; **20 assertions passed**):
   - `CloudProviderFactory.getCloudIdProvider` dispatch for `aws_iam`, `azure_ad`, `gcp` + rejection of an unsupported type (4 assertions).
   - **Full execution of `AwsCloudIdProvider.getCloudId()`** with fake static env credentials (`AWS_ACCESS_KEY_ID=AKIAFAKE...`, `AWS_EC2_METADATA_DISABLED=true`): this code path signs the STS `GetCallerIdentity` request **locally and never sends it**, so it runs end-to-end offline. Verified the returned cloud-id decodes to the expected JSON and the headers JSON (serialized by jackson-databind 2.22.1) contains a SigV4 `AWS4-HMAC-SHA256` Authorization header and `X-Amz-Date` (4 assertions). No request left the machine.
   - Class-linkage checks (`Class.forName`) for 10 classes across the bumped libraries: azure-identity, azure-core, google-auth-library, netty codec-http/ssl/resolver-dns, reactor-netty `HttpClient`, jackson `ObjectMapper`, guava (10 assertions).
   - Offline construction of `DefaultAzureCredential` via `DefaultAzureCredentialBuilder().build()` (no token fetch attempted) (1 assertion).
   - jackson-databind runtime version self-report equals 2.22.1 (1 assertion). Netty's version-properties files are merged away by the assembly plugin in the fat jar, so netty's runtime version is evidenced by `mvn dependency:tree` (all `io.netty:*` at 4.1.137.Final) instead.
5. `mvn -B dependency:tree` - confirms resolved tree: all netty artifacts 4.1.137.Final, reactor-netty-http/core 1.2.18, guava 33.6.0-jre, jackson 2.22.1/2.22, msal4j 1.23.1 with no standalone nimbus-jose-jwt.
6. Re-scan: `trivy fs --scanners vuln --offline-scan -q -f json` - **0 vulnerabilities** (was 50).

**Not run, and why:** `AzureCloudIdProvider.getCloudId()` and `GcpCloudIdProvider.getCloudId()` end-to-end - both require live cloud credentials/metadata endpoints (Azure IMDS / GCP ADC), which are unavailable locally and out of scope per policy of not touching live environments; their code paths are covered by compile, class-linkage, and object-construction checks above. No integration/e2e suites, containers, or CI-only jobs exist in this repository (the `.github` directory contains no test workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated third-party components supporting authentication, cloud identity, JSON processing, and networking.
  * Improved compatibility and reliability by aligning networking component versions and coordinating related updates.
  * Refreshed dependency management to help ensure consistent behavior across supported integrations and reduce version mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
