### PR TITLE
test: add hermetic unit suite + CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: "Tests"
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  java-test:
+    name: Java Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: "11"
+          distribution: "temurin"
+          cache: "maven"
+
+      - name: Run tests
+        run: mvn -B -Drevision=1.0.0-SNAPSHOT test

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,14 @@
             <artifactId>netty-handler</artifactId>
             <version>4.1.121.Final</version>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
    </dependencies>
 
     <distributionManagement>
@@ -85,6 +93,13 @@
 
     <build>
         <plugins>
+            <!-- runs the JUnit test suite during the test phase -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+
             <!-- any other plugins -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/src/test/java/io/akeyless/cloudid/AwsCloudIdProviderTest.java
+++ b/src/test/java/io/akeyless/cloudid/AwsCloudIdProviderTest.java
@@ -1,0 +1,236 @@
+package io.akeyless.cloudid;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Fully hermetic, offline end-to-end tests for {@link AwsCloudIdProvider}.
+ *
+ * <p>The provider resolves credentials through the AWS SDK
+ * {@code DefaultCredentialsProvider} chain. The first link in that chain is the
+ * {@code SystemPropertyCredentialsProvider}, which reads the {@code aws.accessKeyId},
+ * {@code aws.secretAccessKey} and {@code aws.sessionToken} system properties with
+ * <em>no</em> network access. By setting those properties to fake static values we
+ * exercise the whole "sign an STS GetCallerIdentity request and package it as a
+ * cloud-id token" flow without any real credentials or any outbound request.
+ *
+ * <p>SigV4 signing is a purely local computation, so these tests never contact STS.
+ */
+public class AwsCloudIdProviderTest {
+
+    private static final String FAKE_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE";
+    private static final String FAKE_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    private static final String FAKE_SESSION_TOKEN = "FAKESESSIONTOKEN/akeyless-test//////////wEXAMPLE";
+
+    private static final String PROP_ACCESS_KEY = "aws.accessKeyId";
+    private static final String PROP_SECRET_KEY = "aws.secretAccessKey";
+    private static final String PROP_SESSION_TOKEN = "aws.sessionToken";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private String savedAccessKey;
+    private String savedSecretKey;
+    private String savedSessionToken;
+
+    @Before
+    public void injectFakeCredentials() {
+        // Remember whatever the host/CI environment had so we can restore it.
+        savedAccessKey = System.getProperty(PROP_ACCESS_KEY);
+        savedSecretKey = System.getProperty(PROP_SECRET_KEY);
+        savedSessionToken = System.getProperty(PROP_SESSION_TOKEN);
+
+        System.setProperty(PROP_ACCESS_KEY, FAKE_ACCESS_KEY);
+        System.setProperty(PROP_SECRET_KEY, FAKE_SECRET_KEY);
+        // Session token is set per-test where needed; make sure we start clean.
+        System.clearProperty(PROP_SESSION_TOKEN);
+    }
+
+    @After
+    public void restoreCredentials() {
+        restore(PROP_ACCESS_KEY, savedAccessKey);
+        restore(PROP_SECRET_KEY, savedSecretKey);
+        restore(PROP_SESSION_TOKEN, savedSessionToken);
+    }
+
+    private static void restore(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+        } else {
+            System.setProperty(key, value);
+        }
+    }
+
+    // ---- The decoded token model -------------------------------------------------
+
+    /** Decodes the outer base64+JSON envelope and the inner base64 fields. */
+    private static DecodedToken decode(String cloudId) throws Exception {
+        assertNotNull("cloud id must not be null", cloudId);
+        byte[] outer = Base64.getDecoder().decode(cloudId);
+        JsonNode root = MAPPER.readTree(new String(outer, StandardCharsets.UTF_8));
+
+        DecodedToken token = new DecodedToken();
+        token.method = root.get("sts_request_method").asText();
+        token.url = decodeField(root, "sts_request_url");
+        token.body = decodeField(root, "sts_request_body");
+        token.headersJson = decodeField(root, "sts_request_headers");
+        token.headers = MAPPER.readTree(token.headersJson);
+        return token;
+    }
+
+    private static String decodeField(JsonNode root, String field) {
+        JsonNode node = root.get(field);
+        assertNotNull("missing token field: " + field, node);
+        return new String(Base64.getDecoder().decode(node.asText()), StandardCharsets.UTF_8);
+    }
+
+    private static final class DecodedToken {
+        String method;
+        String url;
+        String body;
+        String headersJson;
+        JsonNode headers;
+
+        /** Case-insensitive header lookup; headers are serialized as name -> [values]. */
+        String header(String name) {
+            Iterator<Map.Entry<String, JsonNode>> fields = headers.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> e = fields.next();
+                if (e.getKey().equalsIgnoreCase(name)) {
+                    JsonNode v = e.getValue();
+                    return v.isArray() && v.size() > 0 ? v.get(0).asText() : v.asText();
+                }
+            }
+            return null;
+        }
+
+        boolean hasHeader(String name) {
+            return header(name) != null;
+        }
+    }
+
+    private static DecodedToken getDecodedToken() throws Exception {
+        return decode(new AwsCloudIdProvider().getCloudId());
+    }
+
+    // ---- Envelope / payload shape ------------------------------------------------
+
+    @Test
+    public void tokenIsBase64EncodedJsonBundleWithAllFields() throws Exception {
+        String cloudId = new AwsCloudIdProvider().getCloudId();
+        assertFalse("cloud id must not be empty", cloudId.isEmpty());
+
+        // Outer layer must be valid base64 of a JSON object carrying the 4 STS fields.
+        JsonNode root = MAPPER.readTree(new String(Base64.getDecoder().decode(cloudId), StandardCharsets.UTF_8));
+        assertTrue(root.isObject());
+        assertTrue(root.has("sts_request_method"));
+        assertTrue(root.has("sts_request_url"));
+        assertTrue(root.has("sts_request_body"));
+        assertTrue(root.has("sts_request_headers"));
+    }
+
+    @Test
+    public void methodIsPost() throws Exception {
+        assertEquals("POST", getDecodedToken().method);
+    }
+
+    @Test
+    public void urlDecodesToGlobalStsEndpoint() throws Exception {
+        assertEquals("https://sts.amazonaws.com/", getDecodedToken().url);
+    }
+
+    @Test
+    public void bodyIsGetCallerIdentityAction() throws Exception {
+        assertEquals("Action=GetCallerIdentity&Version=2011-06-15", getDecodedToken().body);
+    }
+
+    // ---- SigV4 signing correctness ----------------------------------------------
+
+    @Test
+    public void authorizationHeaderIsSigV4() throws Exception {
+        String auth = getDecodedToken().header("Authorization");
+        assertNotNull("Authorization header must be present", auth);
+        assertTrue("Authorization must use SigV4 (AWS4-HMAC-SHA256), was: " + auth,
+                auth.startsWith("AWS4-HMAC-SHA256"));
+        assertTrue("Authorization must carry a Signature component", auth.contains("Signature="));
+        assertTrue("Authorization must carry SignedHeaders", auth.contains("SignedHeaders="));
+    }
+
+    @Test
+    public void credentialScopeTargetsUsEast1StsService() throws Exception {
+        String auth = getDecodedToken().header("Authorization");
+        assertNotNull(auth);
+        // Credential scope is <access-key>/<yyyymmdd>/<region>/<service>/aws4_request
+        assertTrue("credential scope must target us-east-1/sts, was: " + auth,
+                auth.contains("/us-east-1/sts/aws4_request"));
+        assertTrue("Authorization must reference the fake access key id",
+                auth.contains("Credential=" + FAKE_ACCESS_KEY + "/"));
+    }
+
+    @Test
+    public void hostHeaderIsGlobalStsHost() throws Exception {
+        assertEquals("sts.amazonaws.com", getDecodedToken().header("Host"));
+    }
+
+    @Test
+    public void xAmzDateHeaderIsPresentAndWellFormed() throws Exception {
+        String date = getDecodedToken().header("X-Amz-Date");
+        assertNotNull("X-Amz-Date header must be present", date);
+        // Format is basic ISO8601: yyyyMMdd'T'HHmmss'Z'
+        assertTrue("X-Amz-Date must match yyyyMMddTHHmmssZ, was: " + date,
+                date.matches("^\\d{8}T\\d{6}Z$"));
+    }
+
+    @Test
+    public void contentTypeHeaderIsFormUrlEncoded() throws Exception {
+        String contentType = getDecodedToken().header("Content-Type");
+        assertNotNull(contentType);
+        assertTrue("Content-Type must be form-urlencoded, was: " + contentType,
+                contentType.startsWith("application/x-www-form-urlencoded"));
+    }
+
+    // ---- Session-token handling --------------------------------------------------
+
+    @Test
+    public void includesSecurityTokenWhenSessionCredentialsUsed() throws Exception {
+        System.setProperty(PROP_SESSION_TOKEN, FAKE_SESSION_TOKEN);
+        DecodedToken token = getDecodedToken();
+        assertEquals("X-Amz-Security-Token must echo the session token",
+                FAKE_SESSION_TOKEN, token.header("X-Amz-Security-Token"));
+        // Session-token requests must also fold the token into the signature.
+        assertTrue(token.header("Authorization").contains("x-amz-security-token"));
+    }
+
+    @Test
+    public void omitsSecurityTokenForStaticCredentials() throws Exception {
+        // injectFakeCredentials() clears the session token, so basic creds are used.
+        DecodedToken token = getDecodedToken();
+        assertFalse("X-Amz-Security-Token must be absent without a session token",
+                token.hasHeader("X-Amz-Security-Token"));
+    }
+
+    // ---- Determinism / independence ---------------------------------------------
+
+    @Test
+    public void structureIsDeterministicAcrossCalls() throws Exception {
+        DecodedToken a = getDecodedToken();
+        DecodedToken b = getDecodedToken();
+        // Method/URL/body are fixed inputs and must never vary between invocations.
+        assertEquals(a.method, b.method);
+        assertEquals(a.url, b.url);
+        assertEquals(a.body, b.body);
+        assertEquals(a.header("Host"), b.header("Host"));
+    }
+}

--- a/src/test/java/io/akeyless/cloudid/AzureCloudIdProviderTest.java
+++ b/src/test/java/io/akeyless/cloudid/AzureCloudIdProviderTest.java
@@ -1,0 +1,41 @@
+package io.akeyless.cloudid;
+
+import com.azure.identity.DefaultAzureCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Offline tests for {@link AzureCloudIdProvider}.
+ *
+ * <p>The provider obtains a token from {@code DefaultAzureCredential}, which requires
+ * live Azure AD / IMDS access. Per the task constraints we do NOT drive a real token
+ * fetch here; we only assert what is provable offline: that the provider is
+ * constructible, is wired into the factory, and that the underlying Azure credential
+ * builder used by {@code getCloudId()} constructs without any network call.
+ */
+public class AzureCloudIdProviderTest {
+
+    @Test
+    public void providerIsConstructibleAndImplementsInterface() {
+        AzureCloudIdProvider provider = new AzureCloudIdProvider();
+        assertNotNull(provider);
+        assertTrue(provider instanceof CloudIdProvider);
+    }
+
+    @Test
+    public void factoryReturnsAzureProvider() {
+        CloudIdProvider provider = CloudProviderFactory.getCloudIdProvider("azure_ad");
+        assertTrue(provider instanceof AzureCloudIdProvider);
+    }
+
+    @Test
+    public void defaultAzureCredentialBuilderConstructsWithoutNetwork() {
+        // Mirrors the credential construction performed inside getCloudId(). Building
+        // the credential is a local operation; no token request is issued here.
+        DefaultAzureCredential credential = new DefaultAzureCredentialBuilder().build();
+        assertNotNull("DefaultAzureCredential should build offline", credential);
+    }
+}

--- a/src/test/java/io/akeyless/cloudid/CloudProviderFactoryTest.java
+++ b/src/test/java/io/akeyless/cloudid/CloudProviderFactoryTest.java
@@ -1,0 +1,89 @@
+package io.akeyless.cloudid;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Hermetic tests for {@link CloudProviderFactory} dispatch logic.
+ * These tests never touch the network or real credentials; they only assert
+ * that the factory maps access-type strings to the correct provider class and
+ * rejects everything else.
+ */
+public class CloudProviderFactoryTest {
+
+    @Test
+    public void mapsAwsIamToAwsProvider() {
+        CloudIdProvider provider = CloudProviderFactory.getCloudIdProvider("aws_iam");
+        assertNotNull(provider);
+        assertTrue("expected an AwsCloudIdProvider", provider instanceof AwsCloudIdProvider);
+        assertTrue("provider must implement CloudIdProvider", provider instanceof CloudIdProvider);
+    }
+
+    @Test
+    public void mapsAzureAdToAzureProvider() {
+        CloudIdProvider provider = CloudProviderFactory.getCloudIdProvider("azure_ad");
+        assertNotNull(provider);
+        assertTrue("expected an AzureCloudIdProvider", provider instanceof AzureCloudIdProvider);
+    }
+
+    @Test
+    public void mapsGcpToGcpProvider() {
+        CloudIdProvider provider = CloudProviderFactory.getCloudIdProvider("gcp");
+        assertNotNull(provider);
+        assertTrue("expected a GcpCloudIdProvider", provider instanceof GcpCloudIdProvider);
+    }
+
+    @Test
+    public void returnsFreshInstanceEachCall() {
+        CloudIdProvider first = CloudProviderFactory.getCloudIdProvider("aws_iam");
+        CloudIdProvider second = CloudProviderFactory.getCloudIdProvider("aws_iam");
+        assertNotSame("factory must not cache/share provider instances", first, second);
+    }
+
+    @Test
+    public void rejectsUnknownType() {
+        try {
+            CloudProviderFactory.getCloudIdProvider("kubernetes");
+            fail("expected RuntimeException for unsupported type");
+        } catch (RuntimeException e) {
+            assertEquals("Unsupported type: kubernetes", e.getMessage());
+        }
+    }
+
+    @Test
+    public void rejectsEmptyType() {
+        try {
+            CloudProviderFactory.getCloudIdProvider("");
+            fail("expected RuntimeException for empty type");
+        } catch (RuntimeException e) {
+            assertEquals("Unsupported type: ", e.getMessage());
+        }
+    }
+
+    @Test
+    public void rejectsNullType() {
+        try {
+            CloudProviderFactory.getCloudIdProvider(null);
+            fail("expected RuntimeException for null type");
+        } catch (RuntimeException e) {
+            assertEquals("Unsupported type: null", e.getMessage());
+        }
+    }
+
+    @Test
+    public void typeMatchIsCaseSensitive() {
+        // The factory uses exact string equality, so a differently-cased value
+        // must be rejected rather than silently mapped.
+        try {
+            CloudProviderFactory.getCloudIdProvider("AWS_IAM");
+            fail("expected RuntimeException for wrong-case type");
+        } catch (RuntimeException e) {
+            assertEquals("Unsupported type: AWS_IAM", e.getMessage());
+        }
+    }
+}

--- a/src/test/java/io/akeyless/cloudid/GcpCloudIdProviderTest.java
+++ b/src/test/java/io/akeyless/cloudid/GcpCloudIdProviderTest.java
@@ -1,0 +1,31 @@
+package io.akeyless.cloudid;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Offline tests for {@link GcpCloudIdProvider}.
+ *
+ * <p>{@code getCloudId()} relies on {@code GoogleCredentials.getApplicationDefault()}
+ * and a live GCP identity-token exchange, which cannot be exercised hermetically.
+ * We therefore only assert the offline-provable facts: the provider is constructible,
+ * implements the common interface, and is wired into the factory. A real end-to-end
+ * exchange is covered (credentials-gated) in {@link LiveCloudIdE2ETest}.
+ */
+public class GcpCloudIdProviderTest {
+
+    @Test
+    public void providerIsConstructibleAndImplementsInterface() {
+        GcpCloudIdProvider provider = new GcpCloudIdProvider();
+        assertNotNull(provider);
+        assertTrue(provider instanceof CloudIdProvider);
+    }
+
+    @Test
+    public void factoryReturnsGcpProvider() {
+        CloudIdProvider provider = CloudProviderFactory.getCloudIdProvider("gcp");
+        assertTrue(provider instanceof GcpCloudIdProvider);
+    }
+}

--- a/src/test/java/io/akeyless/cloudid/LiveCloudIdE2ETest.java
+++ b/src/test/java/io/akeyless/cloudid/LiveCloudIdE2ETest.java
@@ -1,0 +1,58 @@
+package io.akeyless.cloudid;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
+
+/**
+ * Credentials-gated, live-cloud end-to-end tests.
+ *
+ * <p>Every test here is SKIPPED (via JUnit {@code Assume}) unless the corresponding
+ * real cloud credentials are present in the environment. This means the class is
+ * always safe to run in CI with no secrets — it simply reports the tests as skipped —
+ * yet it exercises the real provider flow whenever credentials are available.
+ *
+ * <p>Gating environment variables:
+ * <ul>
+ *   <li>AWS   - {@code AWS_ACCESS_KEY_ID}</li>
+ *   <li>Azure - {@code AZURE_CLIENT_ID}</li>
+ *   <li>GCP   - {@code GOOGLE_APPLICATION_CREDENTIALS}</li>
+ * </ul>
+ */
+public class LiveCloudIdE2ETest {
+
+    private static void assertNonEmptyBase64(String cloudId) {
+        assertNotNull("cloud id must not be null", cloudId);
+        assertTrue("cloud id must not be empty", cloudId.length() > 0);
+        // Must be valid base64 (throws IllegalArgumentException otherwise).
+        byte[] decoded = Base64.getDecoder().decode(cloudId);
+        assertTrue("decoded cloud id must not be empty",
+                new String(decoded, StandardCharsets.UTF_8).length() > 0);
+    }
+
+    @Test
+    public void awsLiveGetCloudId() throws Exception {
+        assumeNotNull(System.getenv("AWS_ACCESS_KEY_ID"));
+        String cloudId = CloudProviderFactory.getCloudIdProvider("aws_iam").getCloudId();
+        assertNonEmptyBase64(cloudId);
+    }
+
+    @Test
+    public void azureLiveGetCloudId() throws Exception {
+        assumeNotNull(System.getenv("AZURE_CLIENT_ID"));
+        String cloudId = CloudProviderFactory.getCloudIdProvider("azure_ad").getCloudId();
+        assertNonEmptyBase64(cloudId);
+    }
+
+    @Test
+    public void gcpLiveGetCloudId() throws Exception {
+        assumeNotNull(System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
+        String cloudId = CloudProviderFactory.getCloudIdProvider("gcp").getCloudId();
+        assertNonEmptyBase64(cloudId);
+    }
+}


### PR DESCRIPTION
## Summary

This repo previously had **no tests** and only a release workflow. This PR adds a thorough, hermetic (network-free, no real credentials) JUnit test suite plus a GitHub Actions test pipeline. No production source was changed.

## Tests added (`src/test/java/io/akeyless/cloudid`)

**`CloudProviderFactoryTest`** (8 cases) — factory dispatch
- `aws_iam` -> `AwsCloudIdProvider`, `azure_ad` -> `AzureCloudIdProvider`, `gcp` -> `GcpCloudIdProvider` (each also asserted `instanceof CloudIdProvider`)
- fresh instance returned per call
- rejects unknown / empty / `null` / wrong-case types with `RuntimeException("Unsupported type: ...")`

**`AwsCloudIdProviderTest`** (12 cases) — AWS path end-to-end, fully offline
- Fake static creds are injected via the `aws.accessKeyId` / `aws.secretAccessKey` / `aws.sessionToken` JVM system properties, which the AWS SDK `SystemPropertyCredentialsProvider` (first link of `DefaultCredentialsProvider`) reads with no network. SigV4 signing is a local computation, so STS is never contacted. Original property values are saved/restored around each test.
- Decodes the produced token: outer base64 -> JSON envelope with `sts_request_method` / `sts_request_url` / `sts_request_body` / `sts_request_headers`, then the inner base64 fields.
- Asserts: method `POST`; url `https://sts.amazonaws.com/`; body `Action=GetCallerIdentity&Version=2011-06-15`; `Authorization` is `AWS4-HMAC-SHA256` with `Signature=` and `SignedHeaders=`; credential scope `/us-east-1/sts/aws4_request` referencing the fake access key; `Host: sts.amazonaws.com`; `X-Amz-Date` matches `yyyyMMddTHHmmssZ`; `Content-Type` form-urlencoded.
- Session token handling: `X-Amz-Security-Token` present (and folded into the signature) when a session token is set, absent for basic creds.
- Structural determinism across calls.

**`AzureCloudIdProviderTest`** (3 cases) — offline only: provider constructible + `instanceof`, factory wiring, and `DefaultAzureCredentialBuilder().build()` constructs with no network (mirrors what `getCloudId()` builds). No live token fetch is asserted.

**`GcpCloudIdProviderTest`** (2 cases) — offline only: provider constructible + `instanceof`, factory wiring. (Live ADC exchange can't be exercised hermetically.)

**`LiveCloudIdE2ETest`** (3 cases, credentials-gated) — real-cloud e2e that is **skipped** unless creds are present, so it never fails CI without secrets but runs when they exist:
- AWS gated on `AWS_ACCESS_KEY_ID`, Azure on `AZURE_CLIENT_ID`, GCP on `GOOGLE_APPLICATION_CREDENTIALS` (via JUnit `Assume.assumeNotNull`). Each asserts a non-empty, valid-base64 cloud id.

## CI added

`.github/workflows/test.yml` — workflow **"Tests"**, on `push` to all branches (`**`) and on `pull_request`, modeled on the go-cloud-id `test.yml`. Sets up JDK 11 (Temurin, Maven cache) and runs `mvn -B -Drevision=1.0.0-SNAPSHOT test`. The `-Drevision` matches the pom's `${revision}` CI-friendly version scheme (as used by the lightweight sibling).

## pom changes

Added `junit:junit:4.13.2` (test scope) and pinned `maven-surefire-plugin` to `3.2.5`. No change to compiler target (8) or runtime deps.

## Local verification

```
mvn -B -Drevision=1.0.0-SNAPSHOT test
```
Result: **BUILD SUCCESS** — `Tests run: 28, Failures: 0, Errors: 0, Skipped: 3` (the 3 skipped are the credentials-gated live e2e tests, correctly skipped locally with no secrets). All dependencies resolve from Maven Central, so the full `mvn test` runs locally with no internal-artifact/JFrog access required; no direct-compile fallback was needed.

Note: assigning/requesting review from @alikdolg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive offline coverage for AWS, Azure, GCP, and cloud-provider selection.
  * Added optional live integration checks for cloud identity generation when credentials are available.
  * Added validation for provider mappings, error handling, authentication details, and generated cloud-ID format.

* **Chores**
  * Configured automated Java test execution for pushes and pull requests.
  * Added JUnit support and Maven test-suite configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->